### PR TITLE
Refactor Blog.Core.Test

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,13 @@ This project is licensed under the GPL-3.0 License - see the [LICENSE](LICENSE) 
     │  │  └─ Program.cs
     │  │
     │  ├─ Blog.Core.Test/       # Blog.Core testing logic lives here
-    │  │  ├─ Fakes/             # Fake objects not in Blog.Core (help with testing)
-    │  │  ├─ Mocks/             # Mock interface implementations powered by Moq
-    │  │  ├─ Stubs/             # Stubs objects provide models with test data
-    │  │  ├─ UnitTests/         # Unit Tests live here (not integration tests!)
+    │  │  ├─ Factories/         # Objects responsible for creating other objects used in tests
+    │  │  │
+    │  │  ├─ Fakes/             # Abstact (fake) objects that implement Blog.Core interfaces
+    │  │  │  ├─ Mocks/          # Objects with mocking functionality (inherit from Stubs)
+    │  │  │  └─ Stubs/          # Objects with stubbing functionality (inherit from Fakes)
+    │  │  │
+    │  │  ├─ UnitTests/         # Unit Tests live here (not integration tests)
     │  │  │
     │  │  ├─ Blog.Core.Test.csproj
     │  │  ├─ genreport.bash     # Runs ReportGenerator on opencover.xml report

--- a/src/Blog.Core.Test/UnitTests/Adapters/BlogPostFileAdapterTests.cs
+++ b/src/Blog.Core.Test/UnitTests/Adapters/BlogPostFileAdapterTests.cs
@@ -8,9 +8,20 @@ namespace Blog.Core.Test
     public class BlogPostFileAdapterTests
     {
         [Fact]
+        public void Add_Returns()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubFileDataAccess = new StubIFileDataAccess<BlogPost>();
+            var fileAdapter = new BlogPostFileAdapter(fakeConfig, stubFileDataAccess);
+            var param_entity = new BlogPostFactory().Create();
+
+            fileAdapter.Add(param_entity);
+        }
+
+        [Fact]
         public void Add_VerifyDataAccess()
         {
-            var fakeConfig = new FakeIConfigurationFactory().StubFakeDataForFileDataAccess().Create();
+            var fakeConfig = MakeFakeConfig();
             var mockFileDataAccess = new MockIFileDataAccess<BlogPost>();
             var fileAdapter = new BlogPostFileAdapter(fakeConfig, mockFileDataAccess);
             var param_entity = new BlogPostFactory().Create();
@@ -22,9 +33,24 @@ namespace Blog.Core.Test
         }
 
         [Fact]
+        public void Delete_Returns()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubFileDataAccess = new StubIFileDataAccess<BlogPost>();
+            var fileAdapter = new BlogPostFileAdapter(fakeConfig, stubFileDataAccess);
+            var param_entity = new BlogPostFactory().Create();
+            var stub_blogPost = new BlogPostFactory().Create();
+            stub_blogPost.PostId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+            var stub_list = new List<BlogPost> { param_entity, stub_blogPost };
+            stubFileDataAccess.StubReadDatabase(stub_list);
+
+            fileAdapter.Delete(param_entity);
+        }
+
+        [Fact]
         public void Delete_VerifyDataAccess()
         {
-            var fakeConfig = new FakeIConfigurationFactory().StubFakeDataForFileDataAccess().Create();
+            var fakeConfig = MakeFakeConfig();
             var mockFileDataAccess = new MockIFileDataAccess<BlogPost>();
             var fileAdapter = new BlogPostFileAdapter(fakeConfig, mockFileDataAccess);
             var param_entity = new BlogPostFactory().Create();
@@ -43,9 +69,24 @@ namespace Blog.Core.Test
         }
 
         [Fact]
+        public void DeleteByAuthorId_Returns()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubFileDataAccess = new StubIFileDataAccess<BlogPost>();
+            var fileAdapter = new BlogPostFileAdapter(fakeConfig, stubFileDataAccess);
+            var stub_blogPost1 = new BlogPostFactory().Create();
+            var stub_blogPost2 = new BlogPostFactory().Create();
+            stub_blogPost2.AuthorId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+            var stub_list = new List<BlogPost> { stub_blogPost1, stub_blogPost2 };
+            stubFileDataAccess.StubReadDatabase(stub_list);
+
+            fileAdapter.DeleteAllByAuthorId(stub_blogPost2.AuthorId);
+        }
+
+        [Fact]
         public void DeleteByAuthorId_VerifyDataAccess()
         {
-            var fakeConfig = new FakeIConfigurationFactory().StubFakeDataForFileDataAccess().Create();
+            var fakeConfig = MakeFakeConfig();
             var mockFileDataAccess = new MockIFileDataAccess<BlogPost>();
             var fileAdapter = new BlogPostFileAdapter(fakeConfig, mockFileDataAccess);
             var stub_blogPost1 = new BlogPostFactory().Create();
@@ -64,9 +105,24 @@ namespace Blog.Core.Test
         }
 
         [Fact]
+        public void Edit_Returns()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubFileDataAccess = new StubIFileDataAccess<BlogPost>();
+            var fileAdapter = new BlogPostFileAdapter(fakeConfig, stubFileDataAccess);
+            var param_entity = new BlogPostFactory().Create();
+            var stub_blogPost = new BlogPostFactory().Create();
+            stub_blogPost.PostId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+            var stub_list = new List<BlogPost> { param_entity, stub_blogPost };
+            stubFileDataAccess.StubReadDatabase(stub_list);
+
+            fileAdapter.Edit(param_entity);
+        }
+
+        [Fact]
         public void Edit_VerifyDataAccess()
         {
-            var fakeConfig = new FakeIConfigurationFactory().StubFakeDataForFileDataAccess().Create();
+            var fakeConfig = MakeFakeConfig();
             var mockFileDataAccess = new MockIFileDataAccess<BlogPost>();
             var fileAdapter = new BlogPostFileAdapter(fakeConfig, mockFileDataAccess);
             var param_entity = new BlogPostFactory().Create();
@@ -88,7 +144,25 @@ namespace Blog.Core.Test
         [Fact]
         public void GetById_ReturnsExpectedBlogPost()
         {
-            var fakeConfig = new FakeIConfigurationFactory().StubFakeDataForFileDataAccess().Create();
+            var fakeConfig = MakeFakeConfig();
+            var stubFileDataAccess = new StubIFileDataAccess<BlogPost>();
+            var fileAdapter = new BlogPostFileAdapter(fakeConfig, stubFileDataAccess);
+            var stub_blogPost1 = new BlogPostFactory().Create();
+            var stub_blogPost2 = new BlogPostFactory().Create();
+            stub_blogPost2.PostId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+            var stub_list = new List<BlogPost> { stub_blogPost1, stub_blogPost2 };
+            stubFileDataAccess.StubReadDatabase(stub_list);
+            var expected = stub_blogPost2;
+
+            var actual = fileAdapter.GetById(stub_blogPost2.PostId);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GetById_VerifyFileDataAccess()
+        {
+            var fakeConfig = MakeFakeConfig();
             var mockFileDataAccess = new MockIFileDataAccess<BlogPost>();
             var fileAdapter = new BlogPostFileAdapter(fakeConfig, mockFileDataAccess);
             var stub_blogPost1 = new BlogPostFactory().Create();
@@ -97,36 +171,66 @@ namespace Blog.Core.Test
             var stub_list = new List<BlogPost> { stub_blogPost1, stub_blogPost2 };
             mockFileDataAccess.StubReadDatabase(stub_list);
             var expected_readDBfilePath = fakeConfig[KeyChain.FileDataAccess_BlogPost_DatabasePath];
-            var expected = stub_blogPost2;
 
-            var actual = fileAdapter.GetById(stub_blogPost2.PostId);
+            fileAdapter.GetById(stub_blogPost2.PostId);
 
             mockFileDataAccess.VerifyReadDatabase(expected_readDBfilePath);
-            Assert.Equal(expected, actual);
         }
 
         [Fact]
         public void List_ReturnsExpectedList()
         {
-            var fakeConfig = new FakeIConfigurationFactory().StubFakeDataForFileDataAccess().Create();
+            var fakeConfig = MakeFakeConfig();
+            var stubFileDataAccess = new StubIFileDataAccess<BlogPost>();
+            var fileAdapter = new BlogPostFileAdapter(fakeConfig, stubFileDataAccess);
+            var stub_blogPost = new BlogPostFactory().Create();
+            var stub_list = new List<BlogPost> { stub_blogPost };
+            stubFileDataAccess.StubReadDatabase(stub_list);
+            var expected = stub_list;
+
+            var actual = fileAdapter.List();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void List_VerifyFileDataAccess()
+        {
+            var fakeConfig = MakeFakeConfig();
             var mockFileDataAccess = new MockIFileDataAccess<BlogPost>();
             var fileAdapter = new BlogPostFileAdapter(fakeConfig, mockFileDataAccess);
             var stub_blogPost = new BlogPostFactory().Create();
             var stub_list = new List<BlogPost> { stub_blogPost };
             mockFileDataAccess.StubReadDatabase(stub_list);
             var expected_readDBfilePath = fakeConfig[KeyChain.FileDataAccess_BlogPost_DatabasePath];
-            var expected = stub_list;
 
-            var actual = fileAdapter.List();
+            fileAdapter.List();
 
             mockFileDataAccess.VerifyReadDatabase(expected_readDBfilePath);
-            Assert.Equal(expected, actual);
         }
 
         [Fact]
         public void ListByAuthorId_ReturnsExpectedList()
         {
-            var fakeConfig = new FakeIConfigurationFactory().StubFakeDataForFileDataAccess().Create();
+            var fakeConfig = MakeFakeConfig();
+            var stubFileDataAccess = new StubIFileDataAccess<BlogPost>();
+            var fileAdapter = new BlogPostFileAdapter(fakeConfig, stubFileDataAccess);
+            var stub_blogPost1 = new BlogPostFactory().Create();
+            var stub_blogPost2 = new BlogPostFactory().Create();
+            stub_blogPost2.AuthorId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+            var stub_list = new List<BlogPost> { stub_blogPost1, stub_blogPost2 };
+            stubFileDataAccess.StubReadDatabase(stub_list);
+            var expected = new List<BlogPost> { stub_blogPost2 };
+
+            var actual = fileAdapter.ListByAuthorId(stub_blogPost2.AuthorId);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ListByAuthorId_VerifyFileDataAccess()
+        {
+            var fakeConfig = MakeFakeConfig();
             var mockFileDataAccess = new MockIFileDataAccess<BlogPost>();
             var fileAdapter = new BlogPostFileAdapter(fakeConfig, mockFileDataAccess);
             var stub_blogPost1 = new BlogPostFactory().Create();
@@ -135,12 +239,17 @@ namespace Blog.Core.Test
             var stub_list = new List<BlogPost> { stub_blogPost1, stub_blogPost2 };
             mockFileDataAccess.StubReadDatabase(stub_list);
             var expected_readDBfilePath = fakeConfig[KeyChain.FileDataAccess_BlogPost_DatabasePath];
-            var expected = new List<BlogPost> { stub_blogPost2 };
 
-            var actual = fileAdapter.ListByAuthorId(stub_blogPost2.AuthorId);
-            
+            fileAdapter.ListByAuthorId(stub_blogPost2.AuthorId);
+
             mockFileDataAccess.VerifyReadDatabase(expected_readDBfilePath);
-            Assert.Equal(expected, actual);
+        }
+
+        private FakeIConfiguration MakeFakeConfig()
+        {
+            return new FakeIConfigurationFactory()
+                .StubFakeDataForFileDataAccess()
+                .Create();
         }
     }
 }

--- a/src/Blog.Core.Test/UnitTests/Adapters/BlogPostSqlServerAdapterTests.cs
+++ b/src/Blog.Core.Test/UnitTests/Adapters/BlogPostSqlServerAdapterTests.cs
@@ -7,6 +7,20 @@ namespace Blog.Core.Test
     public class BlogPostSqlServerAdapterTests
     {
         [Fact]
+        public void Add_Returns()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubSqlParameterBuilder = new StubISqlParameterBuilder();
+            var stubSqlServerDataAccess = new StubISqlServerDataAccess();
+            var sqlServerAdapter = new BlogPostSqlServerAdapter(fakeConfig,
+                stubSqlServerDataAccess, stubSqlParameterBuilder);
+            var param_entity = new BlogPostFactory().Create();
+            stubSqlServerDataAccess.StubExecuteNonQueryStoredProcedure(1);
+
+            sqlServerAdapter.Add(param_entity);
+        }
+
+        [Fact]
         public void Add_VerifySqlParamaterBuilder()
         {
             var fakeConfig = MakeFakeConfig();
@@ -36,6 +50,20 @@ namespace Blog.Core.Test
             sqlServerAdapter.Add(param_entity);
 
             mockSqlServerDataAccess.VerifyExecuteNonQueryStoredProcedureCalled(1);
+        }
+
+        [Fact]
+        public void Delete_Returns()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubSqlParameterBuilder = new StubISqlParameterBuilder();
+            var stubSqlServerDataAccess = new StubISqlServerDataAccess();
+            var sqlServerAdapter = new BlogPostSqlServerAdapter(fakeConfig,
+                stubSqlServerDataAccess, stubSqlParameterBuilder);
+            var param_entity = new BlogPostFactory().Create();
+            stubSqlServerDataAccess.StubExecuteNonQueryStoredProcedure(1);
+
+            sqlServerAdapter.Delete(param_entity);
         }
 
         [Fact]
@@ -71,6 +99,20 @@ namespace Blog.Core.Test
         }
 
         [Fact]
+        public void DeleteAllByAuthorId_Returns()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubSqlParameterBuilder = new StubISqlParameterBuilder();
+            var stubSqlServerDataAccess = new StubISqlServerDataAccess();
+            var sqlServerAdapter = new BlogPostSqlServerAdapter(fakeConfig,
+                stubSqlServerDataAccess, stubSqlParameterBuilder);
+            var param_id = new BlogPostFactory().Create().AuthorId;
+            stubSqlServerDataAccess.StubExecuteNonQueryStoredProcedure(1);
+
+            sqlServerAdapter.DeleteAllByAuthorId(param_id);
+        }
+
+        [Fact]
         public void DeleteAllByAuthorId_VerifySqlParamaterBuilder()
         {
             var fakeConfig = MakeFakeConfig();
@@ -100,6 +142,20 @@ namespace Blog.Core.Test
             sqlServerAdapter.DeleteAllByAuthorId(param_id);
 
             mockSqlServerDataAccess.VerifyExecuteNonQueryStoredProcedureCalled(1);
+        }
+
+        [Fact]
+        public void Edit_Returns()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubSqlParameterBuilder = new StubISqlParameterBuilder();
+            var stubSqlServerDataAccess = new StubISqlServerDataAccess();
+            var sqlServerAdapter = new BlogPostSqlServerAdapter(fakeConfig,
+                stubSqlServerDataAccess, stubSqlParameterBuilder);
+            var param_entity = new BlogPostFactory().Create();
+            stubSqlServerDataAccess.StubExecuteNonQueryStoredProcedure(1);
+
+            sqlServerAdapter.Edit(param_entity);
         }
 
         [Fact]
@@ -135,6 +191,24 @@ namespace Blog.Core.Test
         }
 
         [Fact]
+        public void GetById_ListReturnedContainsBlogPost_ReturnsExpectedBlogPost()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubSqlParameterBuilder = new StubISqlParameterBuilder();
+            var stubSqlServerDataAccess = new StubISqlServerDataAccess();
+            var sqlServerAdapter = new BlogPostSqlServerAdapter(fakeConfig,
+                stubSqlServerDataAccess, stubSqlParameterBuilder);
+            var expected = new BlogPostFactory().Create();
+            var stub_listOfBlogPost = new List<BlogPost> { expected };
+            stubSqlServerDataAccess.StubExecuteReaderStoredProcedure(stub_listOfBlogPost);
+            var param_id = expected.PostId;
+
+            var actual = sqlServerAdapter.GetById(param_id);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void GetById_ListReturnedContainsBlogPost_VerifySqlParameterBuilder()
         {
             var fakeConfig = MakeFakeConfig();
@@ -142,14 +216,13 @@ namespace Blog.Core.Test
             var stubSqlServerDataAccess = new StubISqlServerDataAccess();
             var sqlServerAdapter = new BlogPostSqlServerAdapter(fakeConfig,
                 stubSqlServerDataAccess, mockSqlParameterBuilder);
-            var param_id = new BlogPostFactory().Create().PostId;
-            var expected_blogpost = new BlogPostFactory().Create();
-            var stub_listOfBlogPost = new List<BlogPost> { expected_blogpost };
+            var stub_blogpost = new BlogPostFactory().Create();
+            var stub_listOfBlogPost = new List<BlogPost> { stub_blogpost };
             stubSqlServerDataAccess.StubExecuteReaderStoredProcedure(stub_listOfBlogPost);
+            var param_id = stub_blogpost.PostId;
 
-            var returned_blogpost = sqlServerAdapter.GetById(param_id);
+            sqlServerAdapter.GetById(param_id);
 
-            Assert.Equal(expected_blogpost, returned_blogpost);
             mockSqlParameterBuilder.VerifyBuildSqlParameterCalled<BlogPost>(1);
         }
 
@@ -161,15 +234,30 @@ namespace Blog.Core.Test
             var mockSqlServerDataAccess = new MockISqlServerDataAccess();
             var sqlServerAdapter = new BlogPostSqlServerAdapter(fakeConfig,
                 mockSqlServerDataAccess, stubSqlParameterBuilder);
-            var param_id = new BlogPostFactory().Create().PostId;
-            var expected_blogpost = new BlogPostFactory().Create();
-            var stub_listOfBlogPost = new List<BlogPost> { expected_blogpost };
+            var stub_blogpost = new BlogPostFactory().Create();
+            var stub_listOfBlogPost = new List<BlogPost> { stub_blogpost };
             mockSqlServerDataAccess.StubExecuteReaderStoredProcedure(stub_listOfBlogPost);
+            var param_id = stub_blogpost.PostId;
 
             var returned_blogpost = sqlServerAdapter.GetById(param_id);
 
-            Assert.Equal(expected_blogpost, returned_blogpost);
             mockSqlServerDataAccess.VerifyExecuteReaderStoredProcedureCalled<BlogPost>(1);
+        }
+
+        [Fact]
+        public void GetById_ListReturnedIsEmpty_ReturnsNullBlogPost()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubSqlParameterBuilder = new StubISqlParameterBuilder();
+            var stubSqlServerDataAccess = new StubISqlServerDataAccess();
+            var sqlServerAdapter = new BlogPostSqlServerAdapter(fakeConfig,
+                stubSqlServerDataAccess, stubSqlParameterBuilder);
+            var param_id = new BlogPostFactory().Create().PostId;
+            stubSqlServerDataAccess.StubExecuteReaderStoredProcedure(new List<BlogPost>());
+
+            var returned_blogpost = sqlServerAdapter.GetById(param_id);
+
+            Assert.Null(returned_blogpost);
         }
 
         [Fact]
@@ -183,9 +271,8 @@ namespace Blog.Core.Test
             var param_id = new BlogPostFactory().Create().PostId;
             stubSqlServerDataAccess.StubExecuteReaderStoredProcedure(new List<BlogPost>());
 
-            var returned_blogpost = sqlServerAdapter.GetById(param_id);
+            sqlServerAdapter.GetById(param_id);
 
-            Assert.Null(returned_blogpost);
             mockSqlParameterBuilder.VerifyBuildSqlParameterCalled<BlogPost>(1);
         }
 
@@ -200,10 +287,25 @@ namespace Blog.Core.Test
             var param_id = new BlogPostFactory().Create().PostId;
             mockSqlServerDataAccess.StubExecuteReaderStoredProcedure(new List<BlogPost>());
 
-            var returned_blogpost = sqlServerAdapter.GetById(param_id);
+            sqlServerAdapter.GetById(param_id);
 
-            Assert.Null(returned_blogpost);
             mockSqlServerDataAccess.VerifyExecuteReaderStoredProcedureCalled<BlogPost>(1);
+        }
+
+        [Fact]
+        public void List_ReturnsExpectedList()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubSqlParameterBuilder = new StubISqlParameterBuilder();
+            var stubSqlServerDataAccess = new StubISqlServerDataAccess();
+            var sqlServerAdapter = new BlogPostSqlServerAdapter(fakeConfig,
+                stubSqlServerDataAccess, stubSqlParameterBuilder);
+            var expected = new List<BlogPost> { new BlogPostFactory().Create() };
+            stubSqlServerDataAccess.StubExecuteReaderStoredProcedure(expected);
+
+            var actual = sqlServerAdapter.List();
+
+            Assert.Equal(expected, actual);
         }
 
         [Fact]
@@ -214,13 +316,29 @@ namespace Blog.Core.Test
             var mockSqlServerDataAccess = new MockISqlServerDataAccess();
             var sqlServerAdapter = new BlogPostSqlServerAdapter(fakeConfig,
                 mockSqlServerDataAccess, stubSqlParameterBuilder);
-            var expected_listOfBlogPost = new List<BlogPost> { new BlogPostFactory().Create() };
-            mockSqlServerDataAccess.StubExecuteReaderStoredProcedure(expected_listOfBlogPost);
+            var stub_listOfBlogPost = new List<BlogPost> { new BlogPostFactory().Create() };
+            mockSqlServerDataAccess.StubExecuteReaderStoredProcedure(stub_listOfBlogPost);
 
-            var returned_listOfBlogpost = sqlServerAdapter.List();
+            sqlServerAdapter.List();
 
-            Assert.Equal(expected_listOfBlogPost, returned_listOfBlogpost);
             mockSqlServerDataAccess.VerifyExecuteReaderStoredProcedureCalled<BlogPost>(1);
+        }
+
+        [Fact]
+        public void ListByAuthorId_ReturnsExpectedList()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubSqlParameterBuilder = new StubISqlParameterBuilder();
+            var stubSqlServerDataAccess = new StubISqlServerDataAccess();
+            var sqlServerAdapter = new BlogPostSqlServerAdapter(fakeConfig,
+                stubSqlServerDataAccess, stubSqlParameterBuilder);
+            var param_id = new BlogPostFactory().Create().AuthorId;
+            var expected = new List<BlogPost> { new BlogPostFactory().Create() };
+            stubSqlServerDataAccess.StubExecuteReaderStoredProcedure(expected);
+
+            var actual = sqlServerAdapter.ListByAuthorId(param_id);
+
+            Assert.Equal(expected, actual);
         }
 
         [Fact]
@@ -232,12 +350,11 @@ namespace Blog.Core.Test
             var sqlServerAdapter = new BlogPostSqlServerAdapter(fakeConfig,
                 stubSqlServerDataAccess, mockSqlParameterBuilder);
             var param_id = new BlogPostFactory().Create().AuthorId;
-            var expected_listOfBlogPost = new List<BlogPost> { new BlogPostFactory().Create() };
-            stubSqlServerDataAccess.StubExecuteReaderStoredProcedure(expected_listOfBlogPost);
+            var stub_listOfBlogPost = new List<BlogPost> { new BlogPostFactory().Create() };
+            stubSqlServerDataAccess.StubExecuteReaderStoredProcedure(stub_listOfBlogPost);
 
-            var returned_listOfBlogpost = sqlServerAdapter.ListByAuthorId(param_id);
+            sqlServerAdapter.ListByAuthorId(param_id);
 
-            Assert.Equal(expected_listOfBlogPost, returned_listOfBlogpost);
             mockSqlParameterBuilder.VerifyBuildSqlParameterCalled<BlogPost>(1);
         }
 
@@ -250,12 +367,11 @@ namespace Blog.Core.Test
             var sqlServerAdapter = new BlogPostSqlServerAdapter(fakeConfig,
                 mockSqlServerDataAccess, stubSqlParameterBuilder);
             var param_id = new BlogPostFactory().Create().AuthorId;
-            var expected_listOfBlogPost = new List<BlogPost> { new BlogPostFactory().Create() };
-            mockSqlServerDataAccess.StubExecuteReaderStoredProcedure(expected_listOfBlogPost);
+            var stub_listOfBlogPost = new List<BlogPost> { new BlogPostFactory().Create() };
+            mockSqlServerDataAccess.StubExecuteReaderStoredProcedure(stub_listOfBlogPost);
 
-            var returned_listOfBlogpost = sqlServerAdapter.ListByAuthorId(param_id);
+            sqlServerAdapter.ListByAuthorId(param_id);
 
-            Assert.Equal(expected_listOfBlogPost, returned_listOfBlogpost);
             mockSqlServerDataAccess.VerifyExecuteReaderStoredProcedureCalled<BlogPost>(1);
         }
 

--- a/src/Blog.Core.Test/UnitTests/Adapters/BlogPostWebApiAdapterTests.cs
+++ b/src/Blog.Core.Test/UnitTests/Adapters/BlogPostWebApiAdapterTests.cs
@@ -10,6 +10,18 @@ namespace Blog.Core.Test
     public class BlogPostWebApiAdapterTests
     {
         [Fact]
+        public void Add_Returns()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubWebApiDataAccess = new StubIWebApiDataAccess();
+            var webApiAdapter = new BlogPostWebApiAdapter(fakeConfig, stubWebApiDataAccess);
+            var param_entity = new BlogPostFactory().Create();
+            stubWebApiDataAccess.StubSendRequest(MakeHttpResponseMessage(HttpStatusCode.OK));
+
+            webApiAdapter.Add(param_entity);
+        }
+
+        [Fact]
         public void Add_VerifySendRequestCalled()
         {
             var fakeConfig = MakeFakeConfig();
@@ -21,6 +33,18 @@ namespace Blog.Core.Test
             webApiAdapter.Add(param_entity);
 
             mockWebApiDataAccess.VerifySendRequestCalled(1);
+        }
+
+        [Fact]
+        public void Delete_Returns()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubWebApiDataAccess = new StubIWebApiDataAccess();
+            var webApiAdapter = new BlogPostWebApiAdapter(fakeConfig, stubWebApiDataAccess);
+            var param_entity = new BlogPostFactory().Create();
+            stubWebApiDataAccess.StubSendRequest(MakeHttpResponseMessage(HttpStatusCode.OK));
+
+            webApiAdapter.Delete(param_entity);
         }
 
         [Fact]
@@ -38,6 +62,18 @@ namespace Blog.Core.Test
         }
 
         [Fact]
+        public void DeleteByAuthorId_Returns()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubWebApiDataAccess = new StubIWebApiDataAccess();
+            var webApiAdapter = new BlogPostWebApiAdapter(fakeConfig, stubWebApiDataAccess);
+            var param_id = new BlogPostFactory().Create().AuthorId;
+            stubWebApiDataAccess.StubSendRequest(MakeHttpResponseMessage(HttpStatusCode.OK));
+
+            webApiAdapter.DeleteAllByAuthorId(param_id);
+        }
+
+        [Fact]
         public void DeleteByAuthorId_VerifySendRequestCalled()
         {
             var fakeConfig = MakeFakeConfig();
@@ -49,6 +85,18 @@ namespace Blog.Core.Test
             webApiAdapter.DeleteAllByAuthorId(param_id);
 
             mockWebApiDataAccess.VerifySendRequestCalled(1);
+        }
+
+        [Fact]
+        public void Edit_Return()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubWebApiDataAccess = new StubIWebApiDataAccess();
+            var webApiAdapter = new BlogPostWebApiAdapter(fakeConfig, stubWebApiDataAccess);
+            var param_entity = new BlogPostFactory().Create();
+            stubWebApiDataAccess.StubSendRequest(MakeHttpResponseMessage(HttpStatusCode.OK));
+
+            webApiAdapter.Edit(param_entity);
         }
 
         [Fact]
@@ -66,42 +114,58 @@ namespace Blog.Core.Test
         }
 
         [Fact]
-        public void GetById_VerifySendRequestCalledAndExpectedBlogPostReturned()
+        public void GetById_ReturnsExpectedBlogPost()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubWebApiDataAccess = new StubIWebApiDataAccess();
+            var webApiAdapter = new BlogPostWebApiAdapter(fakeConfig, stubWebApiDataAccess);
+            var param_id = new BlogPostFactory().Create().PostId;
+            var expected = new BlogPostFactory().Create();
+            var stub_response = MakeHttpResponseMessage(HttpStatusCode.OK);
+            stub_response.Content = new StringContent(JsonConvert.SerializeObject(expected));
+            stubWebApiDataAccess.StubSendRequest(stub_response);
+
+            var actual = webApiAdapter.GetById(param_id);
+
+            AssertBlogPostAreEqual(expected, actual);
+        }
+
+        [Fact]
+        public void GetById_VerifySendRequestCalled()
         {
             var fakeConfig = MakeFakeConfig();
             var mockWebApiDataAccess = new MockIWebApiDataAccess();
             var webApiAdapter = new BlogPostWebApiAdapter(fakeConfig, mockWebApiDataAccess);
             var param_id = new BlogPostFactory().Create().PostId;
-            var expected_return = new BlogPostFactory().Create();
+            var stub_expectedBlogPost = new BlogPostFactory().Create();
             var stub_response = MakeHttpResponseMessage(HttpStatusCode.OK);
-            stub_response.Content = new StringContent(JsonConvert.SerializeObject(expected_return));
+            stub_response.Content = new StringContent(JsonConvert.SerializeObject(stub_expectedBlogPost));
             mockWebApiDataAccess.StubSendRequest(stub_response);
 
-            var actual_return = webApiAdapter.GetById(param_id);
+            webApiAdapter.GetById(param_id);
 
             mockWebApiDataAccess.VerifySendRequestCalled(1);
-            AssertBlogPostAreEqual(expected_return, actual_return);
         }
 
         [Fact]
-        public void List_VerifySendRequestCalledAndExpectedListReturned()
+        public void List_ReturnsExpectedList()
         {
             var fakeConfig = MakeFakeConfig();
-            var mockWebApiDataAccess = new MockIWebApiDataAccess();
-            var webApiAdapter = new BlogPostWebApiAdapter(fakeConfig, mockWebApiDataAccess);
-            var expected_return = new List<BlogPost> { new BlogPostFactory().Create() };
+            var stubWebApiDataAccess = new StubIWebApiDataAccess();
+            var webApiAdapter = new BlogPostWebApiAdapter(fakeConfig, stubWebApiDataAccess);
+            var stub_entity = new BlogPostFactory().Create();
+            var expected = new List<BlogPost> { stub_entity };
             var stub_response = MakeHttpResponseMessage(HttpStatusCode.OK);
-            stub_response.Content = new StringContent(JsonConvert.SerializeObject(expected_return));
-            mockWebApiDataAccess.StubSendRequest(stub_response);
+            stub_response.Content = new StringContent(JsonConvert.SerializeObject(expected));
+            stubWebApiDataAccess.StubSendRequest(stub_response);
 
-            var actual_return = webApiAdapter.List();
+            var actual = webApiAdapter.List();
 
-            mockWebApiDataAccess.VerifySendRequestCalled(1);
-            AssertListOfBlogPostAreEqual(expected_return, actual_return);
+            AssertListOfBlogPostAreEqual(expected, actual);
         }
 
         [Fact]
-        public void ListByAuthorId_VerifySendRequestCalledAndExpectedListReturned()
+        public void List_VerifySendRequestCalled()
         {
             var fakeConfig = MakeFakeConfig();
             var mockWebApiDataAccess = new MockIWebApiDataAccess();
@@ -111,12 +175,45 @@ namespace Blog.Core.Test
             var stub_response = MakeHttpResponseMessage(HttpStatusCode.OK);
             stub_response.Content = new StringContent(JsonConvert.SerializeObject(stub_list));
             mockWebApiDataAccess.StubSendRequest(stub_response);
+
+            webApiAdapter.List();
+
+            mockWebApiDataAccess.VerifySendRequestCalled(1);
+        }
+
+        [Fact]
+        public void ListByAuthorId_ReturnsExpectedList()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubWebApiDataAccess = new StubIWebApiDataAccess();
+            var webApiAdapter = new BlogPostWebApiAdapter(fakeConfig, stubWebApiDataAccess);
+            var stub_entity = new BlogPostFactory().Create();
+            var stub_list = new List<BlogPost> { stub_entity };
+            var stub_response = MakeHttpResponseMessage(HttpStatusCode.OK);
+            stub_response.Content = new StringContent(JsonConvert.SerializeObject(stub_list));
+            stubWebApiDataAccess.StubSendRequest(stub_response);
             var expected = stub_list;
 
             var actual = webApiAdapter.ListByAuthorId(stub_entity.AuthorId);
 
-            mockWebApiDataAccess.VerifySendRequestCalled(1);
             AssertListOfBlogPostAreEqual(expected, actual);
+        }
+
+        [Fact]
+        public void ListByAuthorId_VerifySendRequestCalled()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var mockWebApiDataAccess = new MockIWebApiDataAccess();
+            var webApiAdapter = new BlogPostWebApiAdapter(fakeConfig, mockWebApiDataAccess);
+            var stub_entity = new BlogPostFactory().Create();
+            var stub_list = new List<BlogPost> { stub_entity };
+            var stub_response = MakeHttpResponseMessage(HttpStatusCode.OK);
+            stub_response.Content = new StringContent(JsonConvert.SerializeObject(stub_list));
+            mockWebApiDataAccess.StubSendRequest(stub_response);
+
+            webApiAdapter.ListByAuthorId(stub_entity.AuthorId);
+
+            mockWebApiDataAccess.VerifySendRequestCalled(1);
         }
 
         private void AssertBlogPostAreEqual(BlogPost expected, BlogPost actual)

--- a/src/Blog.Core.Test/UnitTests/Adapters/BlogUserFileAdapterTests.cs
+++ b/src/Blog.Core.Test/UnitTests/Adapters/BlogUserFileAdapterTests.cs
@@ -8,9 +8,20 @@ namespace Blog.Core.Test
     public class BlogUserFileAdapterTests
     {
         [Fact]
+        public void Add_Returns()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubFileDataAccess = new StubIFileDataAccess<BlogUser>();
+            var fileAdapter = new BlogUserFileAdapter(fakeConfig, stubFileDataAccess);
+            var param_entity = new BlogUserFactory().Create();
+
+            fileAdapter.Add(param_entity);
+        }
+
+        [Fact]
         public void Add_VerifyDataAccess()
         {
-            var fakeConfig = new FakeIConfigurationFactory().StubFakeDataForFileDataAccess().Create();
+            var fakeConfig = MakeFakeConfig();
             var mockFileDataAccess = new MockIFileDataAccess<BlogUser>();
             var fileAdapter = new BlogUserFileAdapter(fakeConfig, mockFileDataAccess);
             var param_entity = new BlogUserFactory().Create();
@@ -22,9 +33,24 @@ namespace Blog.Core.Test
         }
 
         [Fact]
+        public void Delete_Returns()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubFileDataAccess = new StubIFileDataAccess<BlogUser>();
+            var fileAdapter = new BlogUserFileAdapter(fakeConfig, stubFileDataAccess);
+            var param_entity = new BlogUserFactory().Create();
+            var stub_blogUser = new BlogUserFactory().Create();
+            stub_blogUser.UserId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+            var stub_list = new List<BlogUser> { param_entity, stub_blogUser };
+            stubFileDataAccess.StubReadDatabase(stub_list);
+
+            fileAdapter.Delete(param_entity);
+        }
+
+        [Fact]
         public void Delete_VerifyDataAccess()
         {
-            var fakeConfig = new FakeIConfigurationFactory().StubFakeDataForFileDataAccess().Create();
+            var fakeConfig = MakeFakeConfig();
             var mockFileDataAccess = new MockIFileDataAccess<BlogUser>();
             var fileAdapter = new BlogUserFileAdapter(fakeConfig, mockFileDataAccess);
             var param_entity = new BlogUserFactory().Create();
@@ -43,9 +69,24 @@ namespace Blog.Core.Test
         }
 
         [Fact]
+        public void Edit_Returns()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubFileDataAccess = new StubIFileDataAccess<BlogUser>();
+            var fileAdapter = new BlogUserFileAdapter(fakeConfig, stubFileDataAccess);
+            var param_entity = new BlogUserFactory().Create();
+            var stub_blogUser = new BlogUserFactory().Create();
+            stub_blogUser.UserId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+            var stub_list = new List<BlogUser> { param_entity, stub_blogUser };
+            stubFileDataAccess.StubReadDatabase(stub_list);
+
+            fileAdapter.Edit(param_entity);
+        }
+
+        [Fact]
         public void Edit_VerifyDataAccess()
         {
-            var fakeConfig = new FakeIConfigurationFactory().StubFakeDataForFileDataAccess().Create();
+            var fakeConfig = MakeFakeConfig();
             var mockFileDataAccess = new MockIFileDataAccess<BlogUser>();
             var fileAdapter = new BlogUserFileAdapter(fakeConfig, mockFileDataAccess);
             var param_entity = new BlogUserFactory().Create();
@@ -67,7 +108,25 @@ namespace Blog.Core.Test
         [Fact]
         public void GetById_ReturnsExpectedBlogUser()
         {
-            var fakeConfig = new FakeIConfigurationFactory().StubFakeDataForFileDataAccess().Create();
+            var fakeConfig = MakeFakeConfig();
+            var stubFileDataAccess = new StubIFileDataAccess<BlogUser>();
+            var fileAdapter = new BlogUserFileAdapter(fakeConfig, stubFileDataAccess);
+            var stub_blogUser1 = new BlogUserFactory().Create();
+            var stub_blogUser2 = new BlogUserFactory().Create();
+            stub_blogUser2.UserId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+            var stub_list = new List<BlogUser> { stub_blogUser1, stub_blogUser2 };
+            stubFileDataAccess.StubReadDatabase(stub_list);
+            var expected = stub_blogUser2;
+
+            var actual = fileAdapter.GetById(stub_blogUser2.UserId);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GetById_VerifyFileDataAccess()
+        {
+            var fakeConfig = MakeFakeConfig();
             var mockFileDataAccess = new MockIFileDataAccess<BlogUser>();
             var fileAdapter = new BlogUserFileAdapter(fakeConfig, mockFileDataAccess);
             var stub_blogUser1 = new BlogUserFactory().Create();
@@ -76,30 +135,49 @@ namespace Blog.Core.Test
             var stub_list = new List<BlogUser> { stub_blogUser1, stub_blogUser2 };
             mockFileDataAccess.StubReadDatabase(stub_list);
             var expected_readDBfilePath = fakeConfig[KeyChain.FileDataAccess_BlogUser_DatabasePath];
-            var expected = stub_blogUser2;
 
-            var actual = fileAdapter.GetById(stub_blogUser2.UserId);
+            fileAdapter.GetById(stub_blogUser2.UserId);
 
             mockFileDataAccess.VerifyReadDatabase(expected_readDBfilePath);
-            Assert.Equal(expected, actual);
         }
 
         [Fact]
         public void List_ReturnsExpectedList()
         {
-            var fakeConfig = new FakeIConfigurationFactory().StubFakeDataForFileDataAccess().Create();
+            var fakeConfig = MakeFakeConfig();
+            var stubFileDataAccess = new StubIFileDataAccess<BlogUser>();
+            var fileAdapter = new BlogUserFileAdapter(fakeConfig, stubFileDataAccess);
+            var stub_blogUser = new BlogUserFactory().Create();
+            var stub_list = new List<BlogUser> { stub_blogUser };
+            stubFileDataAccess.StubReadDatabase(stub_list);
+            var expected = stub_list;
+
+            var actual = fileAdapter.List();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void List_VerifyFileDataAccess()
+        {
+            var fakeConfig = MakeFakeConfig();
             var mockFileDataAccess = new MockIFileDataAccess<BlogUser>();
             var fileAdapter = new BlogUserFileAdapter(fakeConfig, mockFileDataAccess);
             var stub_blogUser = new BlogUserFactory().Create();
             var stub_list = new List<BlogUser> { stub_blogUser };
             mockFileDataAccess.StubReadDatabase(stub_list);
             var expected_readDBfilePath = fakeConfig[KeyChain.FileDataAccess_BlogUser_DatabasePath];
-            var expected = stub_list;
 
-            var actual = fileAdapter.List();
+            fileAdapter.List();
 
             mockFileDataAccess.VerifyReadDatabase(expected_readDBfilePath);
-            Assert.Equal(expected, actual);
+        }
+
+        private FakeIConfiguration MakeFakeConfig()
+        {
+            return new FakeIConfigurationFactory()
+                .StubFakeDataForFileDataAccess()
+                .Create();
         }
     }
 }

--- a/src/Blog.Core.Test/UnitTests/Adapters/BlogUserSqlServerAdapterTests.cs
+++ b/src/Blog.Core.Test/UnitTests/Adapters/BlogUserSqlServerAdapterTests.cs
@@ -7,6 +7,20 @@ namespace Blog.Core.Test
     public class BlogUserSqlServerAdapterTests
     {
         [Fact]
+        public void Add_Returns()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubSqlParameterBuilder = new StubISqlParameterBuilder();
+            var stubSqlServerDataAccess = new StubISqlServerDataAccess();
+            var sqlServerAdapter = new BlogUserSqlServerAdapter(fakeConfig,
+                stubSqlServerDataAccess, stubSqlParameterBuilder);
+            var param_entity = new BlogUserFactory().Create();
+            stubSqlServerDataAccess.StubExecuteNonQueryStoredProcedure(1);
+
+            sqlServerAdapter.Add(param_entity);
+        }
+
+        [Fact]
         public void Add_VerifySqlParamaterBuilder()
         {
             var fakeConfig = MakeFakeConfig();
@@ -36,6 +50,20 @@ namespace Blog.Core.Test
             sqlServerAdapter.Add(param_entity);
 
             mockSqlServerDataAccess.VerifyExecuteNonQueryStoredProcedureCalled(1);
+        }
+
+        [Fact]
+        public void Delete_Returns()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubSqlParameterBuilder = new StubISqlParameterBuilder();
+            var stubSqlServerDataAccess = new StubISqlServerDataAccess();
+            var sqlServerAdapter = new BlogUserSqlServerAdapter(fakeConfig,
+                stubSqlServerDataAccess, stubSqlParameterBuilder);
+            var param_entity = new BlogUserFactory().Create();
+            stubSqlServerDataAccess.StubExecuteNonQueryStoredProcedure(1);
+
+            sqlServerAdapter.Delete(param_entity);
         }
 
         [Fact]
@@ -69,6 +97,21 @@ namespace Blog.Core.Test
 
             mockSqlServerDataAccess.VerifyExecuteNonQueryStoredProcedureCalled(1);
         }
+
+        [Fact]
+        public void Edit_Returns()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubSqlParameterBuilder = new StubISqlParameterBuilder();
+            var stubSqlServerDataAccess = new StubISqlServerDataAccess();
+            var sqlServerAdapter = new BlogUserSqlServerAdapter(fakeConfig,
+                stubSqlServerDataAccess, stubSqlParameterBuilder);
+            var param_entity = new BlogUserFactory().Create();
+            stubSqlServerDataAccess.StubExecuteNonQueryStoredProcedure(1);
+
+            sqlServerAdapter.Edit(param_entity);
+        }
+
         [Fact]
         public void Edit_VerifySqlParamaterBuilder()
         {
@@ -102,6 +145,24 @@ namespace Blog.Core.Test
         }
 
         [Fact]
+        public void GetById_ListReturnedContainsBlogUser_ReturnsExpectedBlogUser()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubSqlParameterBuilder = new StubISqlParameterBuilder();
+            var stubSqlServerDataAccess = new StubISqlServerDataAccess();
+            var sqlServerAdapter = new BlogUserSqlServerAdapter(fakeConfig,
+                stubSqlServerDataAccess, stubSqlParameterBuilder);
+            var expected = new BlogUserFactory().Create();
+            var stub_listOfBlogUser = new List<BlogUser> { expected };
+            stubSqlServerDataAccess.StubExecuteReaderStoredProcedure(stub_listOfBlogUser);
+            var param_id = expected.UserId;
+
+            var actual = sqlServerAdapter.GetById(param_id);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void GetById_ListReturnedContainsBlogUser_VerifySqlParameterBuilder()
         {
             var fakeConfig = MakeFakeConfig();
@@ -109,14 +170,13 @@ namespace Blog.Core.Test
             var stubSqlServerDataAccess = new StubISqlServerDataAccess();
             var sqlServerAdapter = new BlogUserSqlServerAdapter(fakeConfig,
                 stubSqlServerDataAccess, mockSqlParameterBuilder);
-            var param_id = new BlogUserFactory().Create().UserId;
-            var expected_blogpost = new BlogUserFactory().Create();
-            var stub_listOfBlogUser = new List<BlogUser> { expected_blogpost };
+            var stub_blogpost = new BlogUserFactory().Create();
+            var stub_listOfBlogUser = new List<BlogUser> { stub_blogpost };
             stubSqlServerDataAccess.StubExecuteReaderStoredProcedure(stub_listOfBlogUser);
+            var param_id = stub_blogpost.UserId;
 
-            var returned_blogpost = sqlServerAdapter.GetById(param_id);
+            sqlServerAdapter.GetById(param_id);
 
-            Assert.Equal(expected_blogpost, returned_blogpost);
             mockSqlParameterBuilder.VerifyBuildSqlParameterCalled<BlogUser>(1);
         }
 
@@ -128,15 +188,30 @@ namespace Blog.Core.Test
             var mockSqlServerDataAccess = new MockISqlServerDataAccess();
             var sqlServerAdapter = new BlogUserSqlServerAdapter(fakeConfig,
                 mockSqlServerDataAccess, stubSqlParameterBuilder);
-            var param_id = new BlogUserFactory().Create().UserId;
-            var expected_blogpost = new BlogUserFactory().Create();
-            var stub_listOfBlogUser = new List<BlogUser> { expected_blogpost };
+            var stub_blogpost = new BlogUserFactory().Create();
+            var stub_listOfBlogUser = new List<BlogUser> { stub_blogpost };
             mockSqlServerDataAccess.StubExecuteReaderStoredProcedure(stub_listOfBlogUser);
+            var param_id = stub_blogpost.UserId;
 
             var returned_blogpost = sqlServerAdapter.GetById(param_id);
 
-            Assert.Equal(expected_blogpost, returned_blogpost);
             mockSqlServerDataAccess.VerifyExecuteReaderStoredProcedureCalled<BlogUser>(1);
+        }
+
+        [Fact]
+        public void GetById_ListReturnedIsEmpty_ReturnsNullBlogUser()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubSqlParameterBuilder = new StubISqlParameterBuilder();
+            var stubSqlServerDataAccess = new StubISqlServerDataAccess();
+            var sqlServerAdapter = new BlogUserSqlServerAdapter(fakeConfig,
+                stubSqlServerDataAccess, stubSqlParameterBuilder);
+            var param_id = new BlogUserFactory().Create().UserId;
+            stubSqlServerDataAccess.StubExecuteReaderStoredProcedure(new List<BlogUser>());
+
+            var returned_blogpost = sqlServerAdapter.GetById(param_id);
+
+            Assert.Null(returned_blogpost);
         }
 
         [Fact]
@@ -150,9 +225,8 @@ namespace Blog.Core.Test
             var param_id = new BlogUserFactory().Create().UserId;
             stubSqlServerDataAccess.StubExecuteReaderStoredProcedure(new List<BlogUser>());
 
-            var returned_blogpost = sqlServerAdapter.GetById(param_id);
+            sqlServerAdapter.GetById(param_id);
 
-            Assert.Null(returned_blogpost);
             mockSqlParameterBuilder.VerifyBuildSqlParameterCalled<BlogUser>(1);
         }
 
@@ -167,10 +241,25 @@ namespace Blog.Core.Test
             var param_id = new BlogUserFactory().Create().UserId;
             mockSqlServerDataAccess.StubExecuteReaderStoredProcedure(new List<BlogUser>());
 
-            var returned_blogpost = sqlServerAdapter.GetById(param_id);
+            sqlServerAdapter.GetById(param_id);
 
-            Assert.Null(returned_blogpost);
             mockSqlServerDataAccess.VerifyExecuteReaderStoredProcedureCalled<BlogUser>(1);
+        }
+
+        [Fact]
+        public void List_ReturnsExpectedList()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubSqlParameterBuilder = new StubISqlParameterBuilder();
+            var stubSqlServerDataAccess = new StubISqlServerDataAccess();
+            var sqlServerAdapter = new BlogUserSqlServerAdapter(fakeConfig,
+                stubSqlServerDataAccess, stubSqlParameterBuilder);
+            var expected = new List<BlogUser> { new BlogUserFactory().Create() };
+            stubSqlServerDataAccess.StubExecuteReaderStoredProcedure(expected);
+
+            var actual = sqlServerAdapter.List();
+
+            Assert.Equal(expected, actual);
         }
 
         [Fact]
@@ -181,12 +270,11 @@ namespace Blog.Core.Test
             var mockSqlServerDataAccess = new MockISqlServerDataAccess();
             var sqlServerAdapter = new BlogUserSqlServerAdapter(fakeConfig,
                 mockSqlServerDataAccess, stubSqlParameterBuilder);
-            var expected_listOfBlogUser = new List<BlogUser> { new BlogUserFactory().Create() };
-            mockSqlServerDataAccess.StubExecuteReaderStoredProcedure(expected_listOfBlogUser);
+            var stub_listOfBlogUser = new List<BlogUser> { new BlogUserFactory().Create() };
+            mockSqlServerDataAccess.StubExecuteReaderStoredProcedure(stub_listOfBlogUser);
 
-            var returned_listOfBlogpost = sqlServerAdapter.List();
+            sqlServerAdapter.List();
 
-            Assert.Equal(expected_listOfBlogUser, returned_listOfBlogpost);
             mockSqlServerDataAccess.VerifyExecuteReaderStoredProcedureCalled<BlogUser>(1);
         }
 

--- a/src/Blog.Core.Test/UnitTests/Adapters/BlogUserWebApiAdapterTests.cs
+++ b/src/Blog.Core.Test/UnitTests/Adapters/BlogUserWebApiAdapterTests.cs
@@ -10,6 +10,18 @@ namespace Blog.Core.Test
     public class BlogUserWebApiAdapterTests
     {
         [Fact]
+        public void Add_Returns()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubWebApiDataAccess = new StubIWebApiDataAccess();
+            var webApiAdapter = new BlogUserWebApiAdapter(fakeConfig, stubWebApiDataAccess);
+            var param_entity = new BlogUserFactory().Create();
+            stubWebApiDataAccess.StubSendRequest(MakeHttpResponseMessage(HttpStatusCode.OK));
+
+            webApiAdapter.Add(param_entity);
+        }
+
+        [Fact]
         public void Add_VerifySendRequestCalled()
         {
             var fakeConfig = MakeFakeConfig();
@@ -21,6 +33,18 @@ namespace Blog.Core.Test
             webApiAdapter.Add(param_entity);
 
             mockWebApiDataAccess.VerifySendRequestCalled(1);
+        }
+
+        [Fact]
+        public void Delete_Returns()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubWebApiDataAccess = new StubIWebApiDataAccess();
+            var webApiAdapter = new BlogUserWebApiAdapter(fakeConfig, stubWebApiDataAccess);
+            var param_entity = new BlogUserFactory().Create();
+            stubWebApiDataAccess.StubSendRequest(MakeHttpResponseMessage(HttpStatusCode.OK));
+
+            webApiAdapter.Delete(param_entity);
         }
 
         [Fact]
@@ -38,6 +62,18 @@ namespace Blog.Core.Test
         }
 
         [Fact]
+        public void Edit_Return()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubWebApiDataAccess = new StubIWebApiDataAccess();
+            var webApiAdapter = new BlogUserWebApiAdapter(fakeConfig, stubWebApiDataAccess);
+            var param_entity = new BlogUserFactory().Create();
+            stubWebApiDataAccess.StubSendRequest(MakeHttpResponseMessage(HttpStatusCode.OK));
+
+            webApiAdapter.Edit(param_entity);
+        }
+
+        [Fact]
         public void Edit_VerifySendRequestCalled()
         {
             var fakeConfig = MakeFakeConfig();
@@ -52,38 +88,71 @@ namespace Blog.Core.Test
         }
 
         [Fact]
-        public void GetById_VerifySendRequestCalledAndExpectedBlogUserReturned()
+        public void GetById_ReturnsExpectedBlogUser()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubWebApiDataAccess = new StubIWebApiDataAccess();
+            var webApiAdapter = new BlogUserWebApiAdapter(fakeConfig, stubWebApiDataAccess);
+            var param_id = new BlogUserFactory().Create().UserId;
+            var expected = new BlogUserFactory().Create();
+            var stub_response = MakeHttpResponseMessage(HttpStatusCode.OK);
+            stub_response.Content = new StringContent(JsonConvert.SerializeObject(expected));
+            stubWebApiDataAccess.StubSendRequest(stub_response);
+
+            var actual = webApiAdapter.GetById(param_id);
+
+            AssertBlogUserAreEqual(expected, actual);
+        }
+
+        [Fact]
+        public void GetById_VerifySendRequestCalled()
         {
             var fakeConfig = MakeFakeConfig();
             var mockWebApiDataAccess = new MockIWebApiDataAccess();
             var webApiAdapter = new BlogUserWebApiAdapter(fakeConfig, mockWebApiDataAccess);
             var param_id = new BlogUserFactory().Create().UserId;
-            var expected_return = new BlogUserFactory().Create();
+            var stub_expectedBlogUser = new BlogUserFactory().Create();
             var stub_response = MakeHttpResponseMessage(HttpStatusCode.OK);
-            stub_response.Content = new StringContent(JsonConvert.SerializeObject(expected_return));
+            stub_response.Content = new StringContent(JsonConvert.SerializeObject(stub_expectedBlogUser));
             mockWebApiDataAccess.StubSendRequest(stub_response);
 
-            var actual_return = webApiAdapter.GetById(param_id);
+            webApiAdapter.GetById(param_id);
 
             mockWebApiDataAccess.VerifySendRequestCalled(1);
-            AssertBlogUserAreEqual(expected_return, actual_return);
         }
 
         [Fact]
-        public void List_VerifySendRequestCalledAndExpectedListReturned()
+        public void List_ReturnsExpectedList()
+        {
+            var fakeConfig = MakeFakeConfig();
+            var stubWebApiDataAccess = new StubIWebApiDataAccess();
+            var webApiAdapter = new BlogUserWebApiAdapter(fakeConfig, stubWebApiDataAccess);
+            var stub_entity = new BlogUserFactory().Create();
+            var expected = new List<BlogUser> { stub_entity };
+            var stub_response = MakeHttpResponseMessage(HttpStatusCode.OK);
+            stub_response.Content = new StringContent(JsonConvert.SerializeObject(expected));
+            stubWebApiDataAccess.StubSendRequest(stub_response);
+
+            var actual = webApiAdapter.List();
+
+            AssertListOfBlogUserAreEqual(expected, actual);
+        }
+
+        [Fact]
+        public void List_VerifySendRequestCalled()
         {
             var fakeConfig = MakeFakeConfig();
             var mockWebApiDataAccess = new MockIWebApiDataAccess();
             var webApiAdapter = new BlogUserWebApiAdapter(fakeConfig, mockWebApiDataAccess);
-            var expected_return = new List<BlogUser> { new BlogUserFactory().Create() };
+            var stub_entity = new BlogUserFactory().Create();
+            var stub_list = new List<BlogUser> { stub_entity };
             var stub_response = MakeHttpResponseMessage(HttpStatusCode.OK);
-            stub_response.Content = new StringContent(JsonConvert.SerializeObject(expected_return));
+            stub_response.Content = new StringContent(JsonConvert.SerializeObject(stub_list));
             mockWebApiDataAccess.StubSendRequest(stub_response);
 
-            var actual_return = webApiAdapter.List();
+            webApiAdapter.List();
 
             mockWebApiDataAccess.VerifySendRequestCalled(1);
-            AssertListOfBlogUserAreEqual(expected_return, actual_return);
         }
 
         private void AssertBlogUserAreEqual(BlogUser expected, BlogUser actual)

--- a/src/Blog.Core.Test/UnitTests/DataAccess/FileDataAccessTests.cs
+++ b/src/Blog.Core.Test/UnitTests/DataAccess/FileDataAccessTests.cs
@@ -8,6 +8,17 @@ namespace Blog.Core.Test
     public class FileDataAccessTests
     {
         [Fact]
+        public void ClearDatabase_Returns()
+        {
+            var stubReader = new StubIFileReader();
+            var stubWriter = new StubIFileWriter();
+            var fileDataAccess = new FileDataAccess<FakeBlogModel>(stubReader, stubWriter);
+            var param_filePath = "path/to/the/file.json";
+
+            fileDataAccess.ClearDatabase(param_filePath);
+        }
+
+        [Fact]
         public void ClearDatabase_VerifyWriter()
         {
             var stubReader = new StubIFileReader();
@@ -49,6 +60,18 @@ namespace Blog.Core.Test
         }
 
         [Fact]
+        public void OverwriteDatabase_ListOfEntityIsValid_Returns()
+        {
+            var stubReader = new StubIFileReader();
+            var stubWriter = new StubIFileWriter();
+            var fileDataAccess = new FileDataAccess<FakeBlogModel>(stubReader, stubWriter);
+            var param_filePath = "path/to/the/file.json";
+            var param_listOfEntity = new List<FakeBlogModel> { new FakeBlogModel() };
+
+            fileDataAccess.OverwriteDatabase(param_filePath, param_listOfEntity);
+        }
+
+        [Fact]
         public void OverwriteDatabase_ListOfEntityIsValid_VerifyWriter()
         {
             var stubReader = new StubIFileReader();
@@ -67,21 +90,54 @@ namespace Blog.Core.Test
         [InlineData("")]
         public void ReadDatabase_FileContentsAreNullOrEmpty_ReturnsEmptyList(string stub_fileContents)
         {
-            var mockReader = new MockIFileReader();
+            var stubReader = new StubIFileReader();
             var stubWriter = new StubIFileWriter();
-            var fileDataAccess = new FileDataAccess<FakeBlogModel>(mockReader, stubWriter);
-            mockReader.StubRead(stub_fileContents);
+            var fileDataAccess = new FileDataAccess<FakeBlogModel>(stubReader, stubWriter);
+            stubReader.StubRead(stub_fileContents);
             var param_filePath = "path/to/the/file.json";
             var expected_return = new List<FakeBlogModel>();
 
             var actual_return = fileDataAccess.ReadDatabase(param_filePath);
 
-            mockReader.VerifyRead(param_filePath);
             Assert.Equal(expected_return, actual_return);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void ReadDatabase_FileContentsAreNullOrEmpty_VerifyReader(string stub_fileContents)
+        {
+            var mockReader = new MockIFileReader();
+            var stubWriter = new StubIFileWriter();
+            var fileDataAccess = new FileDataAccess<FakeBlogModel>(mockReader, stubWriter);
+            mockReader.StubRead(stub_fileContents);
+            var param_filePath = "path/to/the/file.json";
+
+            fileDataAccess.ReadDatabase(param_filePath);
+
+            mockReader.VerifyRead(param_filePath);
         }
 
         [Fact]
         public void ReadDatabase_FileContainsOneObject_ReturnsListWithTheOneObject()
+        {
+            var stubReader = new StubIFileReader();
+            var stubWriter = new StubIFileWriter();
+            var fileDataAccess = new FileDataAccess<FakeBlogModel>(stubReader, stubWriter);
+            var param_filePath = "path/to/the/file.json";
+            var stub_listOfEntity = new List<FakeBlogModel> { new FakeBlogModel() };
+            var stub_fileContents = JsonConvert.SerializeObject(stub_listOfEntity);
+            stubReader.StubRead(stub_fileContents);
+            var expected_return = JsonConvert.DeserializeObject<List<FakeBlogModel>>(stub_fileContents);
+
+            var actual_return = fileDataAccess.ReadDatabase(param_filePath);
+
+            Assert.Equal(expected_return.Count, actual_return.Count);
+            Assert.Equal(expected_return[0].FakeProperty, actual_return[0].FakeProperty);
+        }
+
+        [Fact]
+        public void ReadDatabase_FileContainsOneObject_VerifyReader()
         {
             var mockReader = new MockIFileReader();
             var stubWriter = new StubIFileWriter();
@@ -90,13 +146,22 @@ namespace Blog.Core.Test
             var stub_listOfEntity = new List<FakeBlogModel> { new FakeBlogModel() };
             var stub_fileContents = JsonConvert.SerializeObject(stub_listOfEntity);
             mockReader.StubRead(stub_fileContents);
-            var expected_return = JsonConvert.DeserializeObject<List<FakeBlogModel>>(stub_fileContents);
 
-            var actual_return = fileDataAccess.ReadDatabase(param_filePath);
+            fileDataAccess.ReadDatabase(param_filePath);
 
             mockReader.VerifyRead(param_filePath);
-            Assert.Equal(expected_return.Count, actual_return.Count);
-            Assert.Equal(expected_return[0].FakeProperty, actual_return[0].FakeProperty);
+        }
+
+        [Fact]
+        public void WriteToDatabase_EntityIsNull_Returns()
+        {
+            var stubReader = new StubIFileReader();
+            var stubWriter = new StubIFileWriter();
+            var fileDataAccess = new FileDataAccess<FakeBlogModel>(stubReader, stubWriter);
+            var param_filePath = "path/to/the/file.json";
+            FakeBlogModel param_entity = null;
+
+            fileDataAccess.WriteToDatabase(param_filePath, param_entity);
         }
 
         [Fact]
@@ -128,6 +193,18 @@ namespace Blog.Core.Test
         }
 
         [Fact]
+        public void WriteToDatabase_EntityIsValidAndDatabaseIsEmpty_Returns()
+        {
+            var stubReader = new StubIFileReader();
+            var stubWriter = new StubIFileWriter();
+            var fileDataAccess = new FileDataAccess<FakeBlogModel>(stubReader, stubWriter);
+            var param_filePath = "path/to/the/file.json";
+            var param_entity = new FakeBlogModel();
+
+            fileDataAccess.WriteToDatabase(param_filePath, param_entity);
+        }
+
+        [Fact]
         public void WriteToDatabase_EntityIsValidAndDatabaseIsEmpty_VerifyReader()
         {
             var mockReader = new MockIFileReader();
@@ -154,6 +231,20 @@ namespace Blog.Core.Test
             fileDataAccess.WriteToDatabase(param_filePath, param_entity);
 
             mockWriter.VerifyWrite(param_filePath, false, JsonConvert.SerializeObject(expected_listOfEntity));
+        }
+
+        [Fact]
+        public void WriteToDatabase_EntityIsValidAndDatabaseContainsOneObject_Returns()
+        {
+            var stubReader = new StubIFileReader();
+            var stubWriter = new StubIFileWriter();
+            var fileDataAccess = new FileDataAccess<FakeBlogModel>(stubReader, stubWriter);
+            var param_filePath = "path/to/the/file.json";
+            var param_entity = new FakeBlogModel();
+            var stub_listOfEntity = new List<FakeBlogModel> { new FakeBlogModel() };
+            stubReader.StubRead(JsonConvert.SerializeObject(stub_listOfEntity));
+
+            fileDataAccess.WriteToDatabase(param_filePath, param_entity);
         }
 
         [Fact]
@@ -192,6 +283,18 @@ namespace Blog.Core.Test
         }
 
         [Fact]
+        public void WriteToDatabase_ListOfEntityIsNull_Returns()
+        {
+            var stubReader = new StubIFileReader();
+            var stubWriter = new StubIFileWriter();
+            var fileDataAccess = new FileDataAccess<FakeBlogModel>(stubReader, stubWriter);
+            var param_filePath = "path/to/the/file.json";
+            List<FakeBlogModel> param_listOfEntity = null;
+
+            fileDataAccess.WriteToDatabase(param_filePath, param_listOfEntity);
+        }
+
+        [Fact]
         public void WriteToDatabase_ListOfEntityIsNull_VerifyReader()
         {
             var mockReader = new MockIFileReader();
@@ -217,6 +320,18 @@ namespace Blog.Core.Test
             fileDataAccess.WriteToDatabase(param_filePath, param_listOfEntity);
 
             mockWriter.VerifyWriteNeverCalled();
+        }
+
+        [Fact]
+        public void WriteToDatabase_ListOfEntityIsEmpty_Returns()
+        {
+            var stubReader = new StubIFileReader();
+            var stubWriter = new StubIFileWriter();
+            var fileDataAccess = new FileDataAccess<FakeBlogModel>(stubReader, stubWriter);
+            var param_filePath = "path/to/the/file.json";
+            var param_listOfEntity = new List<FakeBlogModel>();
+
+            fileDataAccess.WriteToDatabase(param_filePath, param_listOfEntity);
         }
 
         [Fact]
@@ -248,7 +363,19 @@ namespace Blog.Core.Test
         }
 
         [Fact]
-        public void WriteDatabase_ListOfEntityIsValidAndDatabaseIsEmpty_VerifyReader()
+        public void WriteToDatabase_ListOfEntityIsValidAndDatabaseIsEmpty_Returns()
+        {
+            var stubReader = new StubIFileReader();
+            var stubWriter = new StubIFileWriter();
+            var fileDataAccess = new FileDataAccess<FakeBlogModel>(stubReader, stubWriter);
+            var param_filePath = "path/to/the/file.json";
+            var param_listOfEntity = new List<FakeBlogModel> { new FakeBlogModel() };
+
+            fileDataAccess.WriteToDatabase(param_filePath, param_listOfEntity);
+        }
+
+        [Fact]
+        public void WriteToDatabase_ListOfEntityIsValidAndDatabaseIsEmpty_VerifyReader()
         {
             var mockReader = new MockIFileReader();
             var stubWriter = new StubIFileWriter();
@@ -262,7 +389,7 @@ namespace Blog.Core.Test
         }
 
         [Fact]
-        public void WriteDatabase_ListOfEntityIsValidAndDatabaseIsEmpty_VerifyWriter()
+        public void WriteToDatabase_ListOfEntityIsValidAndDatabaseIsEmpty_VerifyWriter()
         {
             var stubReader = new StubIFileReader();
             var mockWriter = new MockIFileWriter();
@@ -276,7 +403,20 @@ namespace Blog.Core.Test
         }
 
         [Fact]
-        public void WriteDatabase_ListOfEntityIsValidAndDatabaseContainsOneObject_VerifyReader()
+        public void WriteToDatabase_ListOfEntityIsValidAndDatabaseContainsOneObject_Returns()
+        {
+            var stubReader = new StubIFileReader();
+            var stubWriter = new StubIFileWriter();
+            var fileDataAccess = new FileDataAccess<FakeBlogModel>(stubReader, stubWriter);
+            var param_filePath = "path/to/the/file.json";
+            var param_listOfEntity = new List<FakeBlogModel> { new FakeBlogModel() };
+            stubReader.StubRead(JsonConvert.SerializeObject(param_listOfEntity));
+
+            fileDataAccess.WriteToDatabase(param_filePath, param_listOfEntity);
+        }
+
+        [Fact]
+        public void WriteToDatabase_ListOfEntityIsValidAndDatabaseContainsOneObject_VerifyReader()
         {
             var mockReader = new MockIFileReader();
             var stubWriter = new StubIFileWriter();
@@ -291,7 +431,7 @@ namespace Blog.Core.Test
         }
 
         [Fact]
-        public void WriteDatabase_ListOfEntityIsValidAndDatabaseContainsOneObject_VerifyWriter()
+        public void WriteToDatabase_ListOfEntityIsValidAndDatabaseContainsOneObject_VerifyWriter()
         {
             var stubReader = new StubIFileReader();
             var mockWriter = new MockIFileWriter();

--- a/src/Blog.Core.Test/UnitTests/DataAccess/WebApiDataAccessTests.cs
+++ b/src/Blog.Core.Test/UnitTests/DataAccess/WebApiDataAccessTests.cs
@@ -54,14 +54,29 @@ namespace Blog.Core.Test
             var param_request = new HttpRequestMessageFactory().StubHttpRequestMessage().Create();
             var stub_response = new HttpResponseMessageFactory().StubHttpResponseMessage().Create();
             var stub_task = Task.FromResult(stub_response);
+            var stubHandler = new Mock<IFakeHttpMessageHandler>();
+            stubHandler.Setup(x => x.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                .Returns(stub_task);
+            var webApiDataAccess = new WebApiDataAccess(new FakeHttpMessageHandler(stubHandler.Object));
+
+            var returned = webApiDataAccess.SendRequest(param_request);
+
+            Assert.Equal(returned, stub_response);
+        }
+
+        [Fact]
+        public void SendAsync_ValidRequest_VerifyHandler()
+        {
+            var param_request = new HttpRequestMessageFactory().StubHttpRequestMessage().Create();
+            var stub_response = new HttpResponseMessageFactory().StubHttpResponseMessage().Create();
+            var stub_task = Task.FromResult(stub_response);
             var mockHandler = new Mock<IFakeHttpMessageHandler>();
             mockHandler.Setup(x => x.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(stub_task);
             var webApiDataAccess = new WebApiDataAccess(new FakeHttpMessageHandler(mockHandler.Object));
 
-            var returned = webApiDataAccess.SendRequest(param_request);
+            webApiDataAccess.SendRequest(param_request);
 
-            Assert.Equal(returned, stub_response);
             mockHandler.Verify(x => x.SendAsync(param_request, It.IsAny<CancellationToken>()));
         }
     }

--- a/src/Blog.Core.Test/UnitTests/Repositories/BlogPostRepositoryTests.cs
+++ b/src/Blog.Core.Test/UnitTests/Repositories/BlogPostRepositoryTests.cs
@@ -1,10 +1,22 @@
 using Blog.Core.Test.Fakes;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Blog.Core.Test
 {
     public class BlogPostRepositoryTests
     {
+        [Fact]
+        public void Add_ValidBlogPost_Returns()
+        {
+            var stubDataAccessAdapter = new StubIBlogPostDataAccessAdapter();
+            var stubValidator = new StubIBlogPostValidator();
+            var repository = new BlogPostRepository(stubDataAccessAdapter, stubValidator);
+            var param_blogPost = new BlogPostFactory().Create();
+
+            repository.Add(param_blogPost);
+        }
+
         [Fact]
         public void Add_ValidBlogPost_VerifyValidator()
         {
@@ -29,6 +41,17 @@ namespace Blog.Core.Test
             repository.Add(param_blogPost);
 
             mockDataAccessAdapter.VerifyAdd(param_blogPost);
+        }
+
+        [Fact]
+        public void Delete_ValidBlogPost_Returns()
+        {
+            var stubDataAccessAdapter = new StubIBlogPostDataAccessAdapter();
+            var stubValidator = new StubIBlogPostValidator();
+            var repository = new BlogPostRepository(stubDataAccessAdapter, stubValidator);
+            var param_blogPost = new BlogPostFactory().Create();
+
+            repository.Delete(param_blogPost);
         }
 
         [Fact]
@@ -58,6 +81,17 @@ namespace Blog.Core.Test
         }
 
         [Fact]
+        public void DeleteAllByAuthorId_ValidAuthorId_Returns()
+        {
+            var stubDataAccessAdapter = new StubIBlogPostDataAccessAdapter();
+            var stubValidator = new StubIBlogPostValidator();
+            var repository = new BlogPostRepository(stubDataAccessAdapter, stubValidator);
+            var param_authorId = new BlogPostFactory().Create().AuthorId;
+
+            repository.DeleteAllByAuthorId(param_authorId);
+        }
+
+        [Fact]
         public void DeleteAllByAuthorId_ValidAuthorId_VerifyDataAccessAdapter()
         {
             var mockDataAccessAdapter = new MockIBlogPostDataAccessAdapter();
@@ -68,6 +102,17 @@ namespace Blog.Core.Test
             repository.DeleteAllByAuthorId(param_authorId);
 
             mockDataAccessAdapter.VerifyDeleteAllByAuthorId(param_authorId);
+        }
+
+        [Fact]
+        public void Edit_ValidBlogPost_Returns()
+        {
+            var stubDataAccessAdapter = new StubIBlogPostDataAccessAdapter();
+            var stubValidator = new StubIBlogPostValidator();
+            var repository = new BlogPostRepository(stubDataAccessAdapter, stubValidator);
+            var param_blogPost = new BlogPostFactory().Create();
+
+            repository.Edit(param_blogPost);
         }
 
         [Fact]
@@ -97,6 +142,21 @@ namespace Blog.Core.Test
         }
 
         [Fact]
+        public void GetById_ValidBlogPost_ReturnsExpectedBlogPost()
+        {
+            var stubDataAccessAdapter = new StubIBlogPostDataAccessAdapter();
+            var stubValidator = new StubIBlogPostValidator();
+            var repository = new BlogPostRepository(stubDataAccessAdapter, stubValidator);
+            var expected = new BlogPostFactory().Create();
+            stubDataAccessAdapter.StubGetById(expected);
+            var param_authorId = expected.AuthorId;
+
+            var actual = repository.GetById(param_authorId);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void GetById_ValidBlogPost_VerifyDataAccessAdapter()
         {
             var mockDataAccessAdapter = new MockIBlogPostDataAccessAdapter();
@@ -110,6 +170,20 @@ namespace Blog.Core.Test
         }
 
         [Fact]
+        public void List_ValidBlogPost_ReturnsExpectedList()
+        {
+            var stubDataAccessAdapter = new StubIBlogPostDataAccessAdapter();
+            var stubValidator = new StubIBlogPostValidator();
+            var repository = new BlogPostRepository(stubDataAccessAdapter, stubValidator);
+            var expected = new List<BlogPost> { new BlogPostFactory().Create() };
+            stubDataAccessAdapter.StubList(expected);
+
+            var actual = repository.List();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void List_ValidBlogPost_VerifyDataAccessAdapter()
         {
             var mockDataAccessAdapter = new MockIBlogPostDataAccessAdapter();
@@ -119,6 +193,21 @@ namespace Blog.Core.Test
             repository.List();
 
             mockDataAccessAdapter.VerifyList();
+        }
+
+        [Fact]
+        public void ListByAuthorId_ValidAuthorId_ReturnsExpectedList()
+        {
+            var stubDataAccessAdapter = new StubIBlogPostDataAccessAdapter();
+            var stubValidator = new StubIBlogPostValidator();
+            var repository = new BlogPostRepository(stubDataAccessAdapter, stubValidator);
+            var expected = new List<BlogPost> { new BlogPostFactory().Create() };
+            stubDataAccessAdapter.StubListByAuthorId(expected);
+            var param_authorId = expected[0].AuthorId;
+
+            var actual = repository.ListByAuthorId(param_authorId);
+
+            Assert.Equal(expected, actual);
         }
 
         [Fact]

--- a/src/Blog.Core.Test/UnitTests/Repositories/BlogUserRepositoryTests.cs
+++ b/src/Blog.Core.Test/UnitTests/Repositories/BlogUserRepositoryTests.cs
@@ -1,10 +1,22 @@
 using Blog.Core.Test.Fakes;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Blog.Core.Test
 {
     public class BlogUserRepositoryTests
     {
+        [Fact]
+        public void Add_ValidBlogUser_Returns()
+        {
+            var stubDataAccessAdapter = new StubIBlogUserDataAccessAdapter();
+            var stubValidator = new StubIBlogUserValidator();
+            var repository = new BlogUserRepository(stubDataAccessAdapter, stubValidator);
+            var param_blogUser = new BlogUserFactory().Create();
+
+            repository.Add(param_blogUser);
+        }
+
         [Fact]
         public void Add_ValidBlogUser_VerifyValidator()
         {
@@ -29,6 +41,17 @@ namespace Blog.Core.Test
             repository.Add(param_blogUser);
 
             mockDataAccessAdapter.VerifyAdd(param_blogUser);
+        }
+
+        [Fact]
+        public void Delete_ValidBlogUser_Returns()
+        {
+            var stubDataAccessAdapter = new StubIBlogUserDataAccessAdapter();
+            var stubValidator = new StubIBlogUserValidator();
+            var repository = new BlogUserRepository(stubDataAccessAdapter, stubValidator);
+            var param_blogUser = new BlogUserFactory().Create();
+
+            repository.Delete(param_blogUser);
         }
 
         [Fact]
@@ -58,6 +81,17 @@ namespace Blog.Core.Test
         }
 
         [Fact]
+        public void Edit_ValidBlogUser_Returns()
+        {
+            var stubDataAccessAdapter = new StubIBlogUserDataAccessAdapter();
+            var stubValidator = new StubIBlogUserValidator();
+            var repository = new BlogUserRepository(stubDataAccessAdapter, stubValidator);
+            var param_blogUser = new BlogUserFactory().Create();
+
+            repository.Edit(param_blogUser);
+        }
+
+        [Fact]
         public void Edit_ValidBlogUser_VerifyValidator()
         {
             var stubDataAccessAdapter = new StubIBlogUserDataAccessAdapter();
@@ -84,6 +118,21 @@ namespace Blog.Core.Test
         }
 
         [Fact]
+        public void GetById_ValidBlogUser_ReturnsExpectedBlogUser()
+        {
+            var stubDataAccessAdapter = new StubIBlogUserDataAccessAdapter();
+            var stubValidator = new StubIBlogUserValidator();
+            var repository = new BlogUserRepository(stubDataAccessAdapter, stubValidator);
+            var expected = new BlogUserFactory().Create();
+            stubDataAccessAdapter.StubGetById(expected);
+            var param_userId = expected.UserId;
+
+            var actual = repository.GetById(param_userId);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void GetById_ValidBlogUser_VerifyDataAccessAdapter()
         {
             var mockDataAccessAdapter = new MockIBlogUserDataAccessAdapter();
@@ -94,6 +143,20 @@ namespace Blog.Core.Test
             repository.GetById(param_userId);
 
             mockDataAccessAdapter.VerifyGetById(param_userId);
+        }
+
+        [Fact]
+        public void List_ValidBlogUser_ReturnsExpectedList()
+        {
+            var stubDataAccessAdapter = new StubIBlogUserDataAccessAdapter();
+            var stubValidator = new StubIBlogUserValidator();
+            var repository = new BlogUserRepository(stubDataAccessAdapter, stubValidator);
+            var expected = new List<BlogUser> { new BlogUserFactory().Create() };
+            stubDataAccessAdapter.StubList(expected);
+
+            var actual = repository.List();
+
+            Assert.Equal(expected, actual);
         }
 
         [Fact]


### PR DESCRIPTION
This pull request will merge refactor/BlogCoreUnitTests branch with master.

I finished reading The Art Of Unit Testing by Roy Osherove and decided to go back and further separate out my unit tests. Now all tests in Blog.Core.Test only test a single 'unit of work'. Minor readability changes were made where appropriate (i.e. renamed variables, renamed methods, etc.). Also, README.md was updated to reflect the file structure changes in Blog.Core.Test.

This should be the last Blog.Core.Test refactor for a while.